### PR TITLE
Adds more information when a Serialization error is thrown

### DIFF
--- a/LibraryEditor/ViewModels/ActionBarViewModel.cs
+++ b/LibraryEditor/ViewModels/ActionBarViewModel.cs
@@ -218,7 +218,14 @@ namespace Basilisk.LibraryEditor.ViewModels
                     {
                         newLib = Core.Library.FromJson(File.ReadAllText(path));
                     }
-                    catch { }
+                    catch (JsonSerializationException e)
+                    {
+                        MessageBox.Show(
+                            $"Error loading library: {e.Message}",
+                            "Error loading library",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error);
+                    }
                     if (newLib != null)
                     {
 #if DEBUG


### PR DESCRIPTION
Any malformed json file will simply throw a cryptic error without any information in the message.

This pull request adds a more verbose error message in the `catch` step when the `Core.Library.FromJson()` method is used.

Before, a malformed json file would throw the following message:
<img width="476" alt="Screen Shot 2020-01-17 at 3 58 26 PM" src="https://user-images.githubusercontent.com/22966009/72645745-51ba2580-3942-11ea-8e9b-1aabed886e8f.png">

Now, the message will read:
<img width="458" alt="Screen Shot 2020-01-17 at 4 00 00 PM" src="https://user-images.githubusercontent.com/22966009/72645791-71e9e480-3942-11ea-9bbf-86402389df65.png">
This tells me that there is an issue with a GlazingMaterial object with a wrong DirtFactor property. The line number also corresponds to the line in the json file.