### PR TITLE
Adds Setpoint Schedules to Library definition

### DIFF
--- a/Controls/InterfaceModels/ZoneConditioning.cs
+++ b/Controls/InterfaceModels/ZoneConditioning.cs
@@ -52,6 +52,10 @@ namespace Basilisk.Controls.InterfaceModels
         [DefaultValue(true)]
         public bool IsCoolingSetpointConstant { get; set; } = true;
 
+        [SimulationSetting(DisplayName = "IsHeatingSetpointConstant")]
+        [DefaultValue(true)]
+        public bool IsHeatingSetpointConstant { get; set; } = true;
+
         [SimulationSetting(DisplayName = "Cooling setpoint", Units = "degC")]
         [DefaultValue(26)]
         public double CoolingSetpoint { get; set; } = 26;
@@ -61,6 +65,9 @@ namespace Basilisk.Controls.InterfaceModels
 
         [SimulationSetting(DisplayName = "Cooling setpoint schedule")]
         public YearSchedule CoolingSetpointSchedule { get; set; }
+
+        [SimulationSetting(DisplayName = "Heating setpoint schedule")]
+        public YearSchedule HeatingSetpointSchedule { get; set; }
 
         [SimulationSetting(DisplayName = "Cooling limit type")]
         [DefaultValue(IdealSystemLimit.NoLimit)]

--- a/Controls/InterfaceModels/ZoneConditioning.cs
+++ b/Controls/InterfaceModels/ZoneConditioning.cs
@@ -48,12 +48,19 @@ namespace Basilisk.Controls.InterfaceModels
         [DefaultValue(true)]
         public bool IsCoolingOn { get; set; } = true;
 
+        [SimulationSetting(DisplayName = "IsCoolingSetpointConstant")]
+        [DefaultValue(true)]
+        public bool IsCoolingSetpointConstant { get; set; } = true;
+
         [SimulationSetting(DisplayName = "Cooling setpoint", Units = "degC")]
         [DefaultValue(26)]
         public double CoolingSetpoint { get; set; } = 26;
 
         [SimulationSetting(DisplayName = "Cooling schedule")]
         public YearSchedule CoolingSchedule { get; set; }
+
+        [SimulationSetting(DisplayName = "Cooling setpoint schedule")]
+        public YearSchedule CoolingSetpointSchedule { get; set; }
 
         [SimulationSetting(DisplayName = "Cooling limit type")]
         [DefaultValue(IdealSystemLimit.NoLimit)]

--- a/Core/ZoneConditioning.cs
+++ b/Core/ZoneConditioning.cs
@@ -12,6 +12,9 @@ namespace Basilisk.Core
         public YearSchedule CoolingSchedule { get; set; }
 
         [DataMember]
+        public YearSchedule CoolingSetpointSchedule { get; set; }
+
+        [DataMember]
         public double CoolingCoeffOfPerf { get; set; }
 
         [DataMember, DefaultValue(26)]
@@ -58,6 +61,9 @@ namespace Basilisk.Core
 
         [DataMember, DefaultValue(true)]
         public bool IsMechVentOn { get; set; } = true;
+
+        [DataMember, DefaultValue(true)]
+        public bool IsCoolingSetpointConstant { get; set; } = true;
 
         [DataMember, DefaultValue(100)]
         public double MaxCoolFlow { get; set; } = 100;

--- a/Core/ZoneConditioning.cs
+++ b/Core/ZoneConditioning.cs
@@ -15,6 +15,9 @@ namespace Basilisk.Core
         public YearSchedule CoolingSetpointSchedule { get; set; }
 
         [DataMember]
+        public YearSchedule HeatingSetpointSchedule { get; set; }
+
+        [DataMember]
         public double CoolingCoeffOfPerf { get; set; }
 
         [DataMember, DefaultValue(26)]
@@ -64,6 +67,9 @@ namespace Basilisk.Core
 
         [DataMember, DefaultValue(true)]
         public bool IsCoolingSetpointConstant { get; set; } = true;
+
+        [DataMember, DefaultValue(true)]
+        public bool IsHeatingSetpointConstant { get; set; } = true;
 
         [DataMember, DefaultValue(100)]
         public double MaxCoolFlow { get; set; } = 100;


### PR DESCRIPTION
Archsim4Umi allows heating and cooling setpoints to be set as a Schedule. This enables that feature from a Basilisk perspective. Another pull request will handle the change in UMI.

The 4 new parameters are:
1. IsCoolingSetpointConstant
2. IsHeatingSetpointConstant
3. CoolingSetpointSchedule
4. HeatingSetpointSchedule

@ChristophReinhart are those intuitive?
@rosecodym Am I missing other areas of the codebase such that those 4 new parameters are supported in all Basilisk operations?