### PR TITLE
Revert "Adds Setpoint Schedules to Library definition"

### DIFF
--- a/Controls/InterfaceModels/ZoneConditioning.cs
+++ b/Controls/InterfaceModels/ZoneConditioning.cs
@@ -48,26 +48,12 @@ namespace Basilisk.Controls.InterfaceModels
         [DefaultValue(true)]
         public bool IsCoolingOn { get; set; } = true;
 
-        [SimulationSetting(DisplayName = "IsCoolingSetpointConstant")]
-        [DefaultValue(true)]
-        public bool IsCoolingSetpointConstant { get; set; } = true;
-
-        [SimulationSetting(DisplayName = "IsHeatingSetpointConstant")]
-        [DefaultValue(true)]
-        public bool IsHeatingSetpointConstant { get; set; } = true;
-
         [SimulationSetting(DisplayName = "Cooling setpoint", Units = "degC")]
         [DefaultValue(26)]
         public double CoolingSetpoint { get; set; } = 26;
 
         [SimulationSetting(DisplayName = "Cooling schedule")]
         public YearSchedule CoolingSchedule { get; set; }
-
-        [SimulationSetting(DisplayName = "Cooling setpoint schedule")]
-        public YearSchedule CoolingSetpointSchedule { get; set; }
-
-        [SimulationSetting(DisplayName = "Heating setpoint schedule")]
-        public YearSchedule HeatingSetpointSchedule { get; set; }
 
         [SimulationSetting(DisplayName = "Cooling limit type")]
         [DefaultValue(IdealSystemLimit.NoLimit)]

--- a/Core/ZoneConditioning.cs
+++ b/Core/ZoneConditioning.cs
@@ -12,12 +12,6 @@ namespace Basilisk.Core
         public YearSchedule CoolingSchedule { get; set; }
 
         [DataMember]
-        public YearSchedule CoolingSetpointSchedule { get; set; }
-
-        [DataMember]
-        public YearSchedule HeatingSetpointSchedule { get; set; }
-
-        [DataMember]
         public double CoolingCoeffOfPerf { get; set; }
 
         [DataMember, DefaultValue(26)]
@@ -64,12 +58,6 @@ namespace Basilisk.Core
 
         [DataMember, DefaultValue(true)]
         public bool IsMechVentOn { get; set; } = true;
-
-        [DataMember, DefaultValue(true)]
-        public bool IsCoolingSetpointConstant { get; set; } = true;
-
-        [DataMember, DefaultValue(true)]
-        public bool IsHeatingSetpointConstant { get; set; } = true;
 
         [DataMember, DefaultValue(100)]
         public double MaxCoolFlow { get; set; } = 100;


### PR DESCRIPTION
Reverts MITSustainableDesignLab/basilisk#46

That commit doesn't have a backwards compatibility story, which it needs before productionalizing. I'm back it out so that we can release the advanced structure upgrades in the meantime.